### PR TITLE
fix: copy user creation error messages

### DIFF
--- a/everycheese/users/forms.py
+++ b/everycheese/users/forms.py
@@ -11,14 +11,25 @@ class UserChangeForm(forms.UserChangeForm):
 
 
 class UserCreationForm(forms.UserCreationForm):
+    """Form for creating new users with unique usernames.
 
-    error_message = forms.UserCreationForm.error_messages.update(
-        {
-            "duplicate_username": _(
-                "This username has already been taken."
-            )
-        }
-    )
+    The original implementation attempted to update the parent class'
+    ``error_messages`` dictionary in place and stored the return value of
+    ``dict.update`` (which is ``None``) on an ``error_message`` attribute.
+
+    Besides leaving an unused ``error_message`` attribute behind, mutating the
+    parent's dictionary has the side effect of globally changing the error
+    messages for *all* ``UserCreationForm`` usages in the project.  To avoid
+    these issues we create a copy of the parent's ``error_messages`` and extend
+    it with our custom message.
+    """
+
+    error_messages = {
+        **forms.UserCreationForm.error_messages,
+        "duplicate_username": _(
+            "This username has already been taken."
+        ),
+    }
 
     class Meta(forms.UserCreationForm.Meta):
         model = User


### PR DESCRIPTION
## Summary
- avoid mutating parent form's error_messages for duplicate usernames

## Testing
- `pip install -r requirements/local.txt` *(fails: Could not find a version that satisfies the requirement pytz==2019.3)*
- `pytest everycheese/users/tests/test_forms.py::TestUserCreationForm::test_clean_username -q -o addopts=` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_689d892d1dcc83209279e4c1556a5e26